### PR TITLE
fix: image name 条件判断语法错误

### DIFF
--- a/fe-build-image/action.yml
+++ b/fe-build-image/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
       run: |
         REPO_NAME=$(basename ${{ github.repository }})
-        echo "image_name=$([-n "${{ inputs.image_name }}" ] && echo "${{ inputs.image_name }}" || echo "$REPO_NAME")" >> $GITHUB_OUTPUT
+        echo "image_name=$([ -n "${{ inputs.image_name }}" ] && echo "${{ inputs.image_name }}" || echo "$REPO_NAME")" >> $GITHUB_OUTPUT
 
     - name: Set up Docker registries info
       id: registries


### PR DESCRIPTION
`[` 后面未加空格导致 bash 语法错误，功能无法生效